### PR TITLE
fix #77

### DIFF
--- a/flamby/fed_benchmark.py
+++ b/flamby/fed_benchmark.py
@@ -22,10 +22,9 @@ from flamby.datasets.fed_tcga_brca import (
 )
 from flamby.datasets.fed_tcga_brca import FedTcgaBrca as FedDataset
 from flamby.datasets.fed_tcga_brca import Optimizer, get_nb_max_rounds, metric
+from flamby.utils import evaluate_model_on_tests
 
 NAME_RESULTS_FILE = "results_benchmark_fed_tcga_brca.csv"
-
-from flamby.utils import evaluate_model_on_tests
 
 
 def main(args2):
@@ -157,14 +156,14 @@ def main(args2):
             perf_lines_dicts = df.to_dict("records")
 
         m = copy.deepcopy(global_init)
-        l = BaselineLoss()
+        loss_ = BaselineLoss()
         opt = Optimizer(m.parameters(), lr=LR)
         print("Pooled")
         for e in range(NUM_EPOCHS_POOLED):
             for X, y in train_pooled:
                 opt.zero_grad()
                 y_pred = m(X)
-                loss = l(y_pred, y)
+                loss = loss_(y_pred, y)
                 loss.backward()
                 opt.step()
 
@@ -216,7 +215,7 @@ def main(args2):
 
         for i in range(NUM_CLIENTS):
             m = copy.deepcopy(global_init)
-            l = BaselineLoss()
+            loss_ = BaselineLoss()
             print(LR)
             opt = Optimizer(m.parameters(), lr=LR)
             print("Local " + str(i))
@@ -224,7 +223,7 @@ def main(args2):
                 for X, y in training_dls[i]:
                     opt.zero_grad()
                     y_pred = m(X)
-                    loss = l(y_pred, y)
+                    loss = loss_(y_pred, y)
                     loss.backward()
                     opt.step()
 
@@ -310,11 +309,11 @@ def main(args2):
         for sname in strategy_names:
             # Base arguments
             m = copy.deepcopy(global_init)
-            l = BaselineLoss()
+            loss_ = BaselineLoss()
             args = {
                 "training_dataloaders": training_dls,
                 "model": m,
-                "loss": l,
+                "loss": loss_,
                 "optimizer_class": Optimizer,
                 "learning_rate": LR,
                 "num_updates": num_updates,

--- a/flamby/strategies/cyclic.py
+++ b/flamby/strategies/cyclic.py
@@ -1,4 +1,5 @@
 import time
+from datetime import datetime
 from typing import List
 
 import numpy as np
@@ -6,6 +7,9 @@ import torch
 from tqdm import tqdm
 
 from .utils import DataLoaderWithMemory, _Model
+
+DATE_NOW = datetime.now().strftime("%b%d_%H-%M-%S")
+LOG_DIR = f"./runs/cyclic-{DATE_NOW}"
 
 
 class Cyclic:
@@ -68,6 +72,7 @@ class Cyclic:
         num_updates: int,
         nrounds: int,
         log: bool = False,
+        log_dir: str = LOG_DIR,
         log_period: int = 100,
         bits_counting_function: callable = None,
         deterministic_cycle: bool = True,
@@ -102,6 +107,9 @@ class Cyclic:
         log: bool
             Whether or not to store logs in tensorboard.
 
+        log_dir: str
+            Save directory location. Default is runs/cyclic-**DATE_NOW**
+
         log_period: int
 
         bits_counting_function: callable
@@ -134,6 +142,7 @@ class Cyclic:
                 lr=learning_rate,
                 loss=loss,
                 log=self.log,
+                log_dir=log_dir,
                 client_id=i,
                 log_period=self.log_period,
             )

--- a/flamby/strategies/fed_avg.py
+++ b/flamby/strategies/fed_avg.py
@@ -1,9 +1,13 @@
+from datetime import datetime
 from typing import List
 
 import torch
 from tqdm import tqdm
 
 from flamby.strategies.utils import DataLoaderWithMemory, _Model
+
+DATE_NOW = datetime.now().strftime("%b%d_%H-%M-%S")
+LOG_DIR = f"./runs/fedavg-{DATE_NOW}"
 
 
 class FedAvg:
@@ -30,6 +34,7 @@ class FedAvg:
         num_updates: int,
         nrounds: int,
         log: bool = False,
+        log_dir: str = LOG_DIR,
         log_period: int = 100,
         bits_counting_function: callable = None,
     ):
@@ -54,6 +59,8 @@ class FedAvg:
             The number of communication rounds to do.
         log: bool
             Whether or not to store logs in tensorboard. Defaults to False.
+        log_dir: str
+            Save directory location. Default is runs/fedavg-**DATE_NOW**
         log_period: int
             If log is True then log the loss every log_period batch updates.
             Defauts to 100.
@@ -70,6 +77,7 @@ class FedAvg:
         self.total_number_of_samples = sum(self.training_sizes)
         self.log = log
         self.log_period = log_period
+
         self.models_list = [
             _Model(
                 model=model,
@@ -77,6 +85,7 @@ class FedAvg:
                 lr=learning_rate,
                 loss=loss,
                 log=self.log,
+                log_dir=log_dir,
                 client_id=i,
                 log_period=self.log_period,
             )
@@ -94,7 +103,7 @@ class FedAvg:
         ----------
         _model: _Model
             The model on the local device used by the optimization step.
-        dataloader_with_memory : dataloaderwithmemory
+        dataloader_with_memory : DataLoaderWithMemory
             A dataloader that can be called infinitely using its get_samples()
             method.
         """

--- a/flamby/strategies/fed_opt.py
+++ b/flamby/strategies/fed_opt.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import List
 
 import numpy as np
@@ -26,6 +27,7 @@ class FedOpt:
         num_updates: int,
         nrounds: int,
         log: bool = False,
+        log_dir: str = None,
         log_period: int = 100,
         bits_counting_function: callable = None,
         tau: float = 1e-8,
@@ -45,7 +47,7 @@ class FedOpt:
             The loss to minimize between the predictions of the model and the
             ground truth.
         optimizer_class : torch.optim.Optimizer
-            This is the client optimizer, it has to be SGD is FedAdam is chosen
+            This is the client optimizer, it has to be SGD if FedAdam is chosen
             for the server optimizer. The adaptive logic sits with the server
             optimizer and is coded below with the aggregation.
         learning_rate : float
@@ -59,7 +61,8 @@ class FedOpt:
         bits_counting_function : callable
             A function making sure exchanges respect the rules, this function
             can be obtained by decorating check_exchange_compliance in
-            flamby.utils. Should have the signature List[Tensor] -> int. Defaults to None.
+            flamby.utils. Should have the signature List[Tensor] -> int.
+            Defaults to None.
         tau: float
             adaptivity hyperparameter for the Adam/Yogi optimizer. Defaults to 1e-8.
         server_learning_rate : float
@@ -81,6 +84,11 @@ class FedOpt:
         self.total_number_of_samples = sum(self.training_sizes)
         self.log = log
         self.log_period = log_period
+
+        if log_dir is None:
+            date_now = datetime.now().strftime("%b%d_%H-%M-%S")
+            log_dir = f"./runs/{date_now}"
+
         self.models_list = [
             _Model(
                 model=model,
@@ -89,6 +97,7 @@ class FedOpt:
                 loss=loss,
                 log=self.log,
                 client_id=i,
+                log_dir=log_dir,
                 log_period=self.log_period,
             )
             for i in range(len(training_dataloaders))
@@ -172,6 +181,9 @@ class FedAdam(FedOpt):
 
     """
 
+    DATE_NOW = datetime.now().strftime("%b%d_%H-%M-%S")
+    LOG_DIR = f"./runs/fedadam-{DATE_NOW}"
+
     def __init__(
         self,
         training_dataloaders: List,
@@ -182,6 +194,7 @@ class FedAdam(FedOpt):
         num_updates: int,
         nrounds: int,
         log: bool = False,
+        log_dir: str = LOG_DIR,
         log_period: int = 100,
         bits_counting_function: callable = None,
         tau: float = 1e-3,
@@ -191,20 +204,21 @@ class FedAdam(FedOpt):
     ):
 
         super().__init__(
-            training_dataloaders,
-            model,
-            loss,
-            optimizer_class,
-            learning_rate,
-            num_updates,
-            nrounds,
-            log,
-            log_period,
-            bits_counting_function,
-            tau,
-            server_learning_rate,
-            beta1,
-            beta2,
+            training_dataloaders=training_dataloaders,
+            model=model,
+            loss=loss,
+            optimizer_class=optimizer_class,
+            learning_rate=learning_rate,
+            num_updates=num_updates,
+            nrounds=nrounds,
+            log=log,
+            log_dir=log_dir,
+            log_period=log_period,
+            bits_counting_function=bits_counting_function,
+            tau=tau,
+            server_learning_rate=server_learning_rate,
+            beta1=beta1,
+            beta2=beta2,
         )
 
     def perform_round(self):
@@ -255,6 +269,9 @@ class FedYogi(FedOpt):
 
     """
 
+    DATE_NOW = datetime.now().strftime("%b%d_%H-%M-%S")
+    LOG_DIR = f"./runs/fedyogi-{DATE_NOW}"
+
     def __init__(
         self,
         training_dataloaders: List,
@@ -265,6 +282,7 @@ class FedYogi(FedOpt):
         num_updates: int,
         nrounds: int,
         log: bool = False,
+        log_dir: str = LOG_DIR,
         log_period: int = 100,
         bits_counting_function: callable = None,
         tau: float = 1e-3,
@@ -274,20 +292,21 @@ class FedYogi(FedOpt):
     ):
 
         super().__init__(
-            training_dataloaders,
-            model,
-            loss,
-            optimizer_class,
-            learning_rate,
-            num_updates,
-            nrounds,
-            log,
-            log_period,
-            bits_counting_function,
-            tau,
-            server_learning_rate,
-            beta1,
-            beta2,
+            training_dataloaders=training_dataloaders,
+            model=model,
+            loss=loss,
+            optimizer_class=optimizer_class,
+            learning_rate=learning_rate,
+            num_updates=num_updates,
+            nrounds=nrounds,
+            log=log,
+            log_dir=log_dir,
+            log_period=log_period,
+            bits_counting_function=bits_counting_function,
+            tau=tau,
+            server_learning_rate=server_learning_rate,
+            beta1=beta1,
+            beta2=beta2,
         )
 
     def perform_round(self):
@@ -337,13 +356,16 @@ class FedYogi(FedOpt):
 
 
 class FedAdagrad(FedOpt):
-    """FedYogi Strategy class
+    """FedAdagrad Strategy class
 
     References
     ----------
     https://arxiv.org/abs/2003.00295
 
     """
+
+    DATE_NOW = datetime.now().strftime("%b%d_%H-%M-%S")
+    LOG_DIR = f"./runs/fedadagrad-{DATE_NOW}"
 
     def __init__(
         self,
@@ -355,6 +377,7 @@ class FedAdagrad(FedOpt):
         num_updates: int,
         nrounds: int,
         log: bool = False,
+        log_dir: str = LOG_DIR,
         log_period: int = 100,
         bits_counting_function: callable = None,
         tau: float = 1e-3,
@@ -364,20 +387,21 @@ class FedAdagrad(FedOpt):
     ):
 
         super().__init__(
-            training_dataloaders,
-            model,
-            loss,
-            optimizer_class,
-            learning_rate,
-            num_updates,
-            nrounds,
-            log,
-            log_period,
-            bits_counting_function,
-            tau,
-            server_learning_rate,
-            beta1,
-            beta2,
+            training_dataloaders=training_dataloaders,
+            model=model,
+            loss=loss,
+            optimizer_class=optimizer_class,
+            learning_rate=learning_rate,
+            num_updates=num_updates,
+            nrounds=nrounds,
+            log=log,
+            log_dir=log_dir,
+            log_period=log_period,
+            bits_counting_function=bits_counting_function,
+            tau=tau,
+            server_learning_rate=server_learning_rate,
+            beta1=beta1,
+            beta2=beta2,
         )
 
     def perform_round(self):

--- a/flamby/strategies/fed_prox.py
+++ b/flamby/strategies/fed_prox.py
@@ -1,9 +1,13 @@
+from datetime import datetime
 from typing import List
 
 import torch
 
 from flamby.strategies import FedAvg
 from flamby.strategies.utils import _Model
+
+DATE_NOW = datetime.now().strftime("%b%d_%H-%M-%S")
+LOG_DIR = f"./runs/fedprox-{DATE_NOW}"
 
 
 class FedProx(FedAvg):
@@ -32,6 +36,7 @@ class FedProx(FedAvg):
         nrounds: int,
         mu: float,
         log: bool = False,
+        log_dir: str = LOG_DIR,
         log_period: int = 100,
         bits_counting_function: callable = None,
     ):
@@ -60,6 +65,8 @@ class FedProx(FedAvg):
             that would work for all settings.
         log: bool
             Whether or not to store logs in tensorboard. Defaults to False.
+        log_dir: str
+            Save directory location. Default is runs/fedprox-**DATE_NOW**
         log_period: int
             If log is True then log the loss every log_period batch updates.
             Defauts to 100.
@@ -70,16 +77,17 @@ class FedProx(FedAvg):
             Defaults to None.
         """
         super().__init__(
-            training_dataloaders,
-            model,
-            loss,
-            optimizer_class,
-            learning_rate,
-            num_updates,
-            nrounds,
-            log,
-            log_period,
-            bits_counting_function,
+            training_dataloaders=training_dataloaders,
+            model=model,
+            loss=loss,
+            optimizer_class=optimizer_class,
+            learning_rate=learning_rate,
+            num_updates=num_updates,
+            nrounds=nrounds,
+            log=log,
+            log_dir=log_dir,
+            log_period=log_period,
+            bits_counting_function=bits_counting_function,
         )
         self.mu = mu
 
@@ -90,7 +98,7 @@ class FedProx(FedAvg):
         ----------
         _model: _Model
             The model on the local device used by the optimization step.
-        dataloader_with_memory : dataloaderwithmemory
+        dataloader_with_memory : DataLoaderWithMemory
             A dataloader that can be called infinitely using its get_samples()
             method.
         """

--- a/flamby/strategies/scaffold.py
+++ b/flamby/strategies/scaffold.py
@@ -1,9 +1,13 @@
+from datetime import datetime
 from typing import List
 
 import torch
 
 from flamby.strategies.fed_avg import FedAvg
 from flamby.strategies.utils import _Model
+
+DATE_NOW = datetime.now().strftime("%b%d_%H-%M-%S")
+LOG_DIR = f"./runs/scaffold-{DATE_NOW}"
 
 
 class Scaffold(FedAvg):
@@ -37,6 +41,7 @@ class Scaffold(FedAvg):
         nrounds: int,
         server_learning_rate: float = 1,
         log: bool = False,
+        log_dir: str = LOG_DIR,
         log_period: int = 100,
         bits_counting_function: callable = None,
     ):
@@ -65,6 +70,8 @@ class Scaffold(FedAvg):
             Defaults to 1.
         log: bool
             Whether or not to store logs in tensorboard. Defaults to False.
+        log_dir: str
+            Save directory location. Default is runs/scaffold-**DATE_NOW**
         log_period: int
             If log is True then log the loss every log_period batch updates.
             Defauts to 100.
@@ -80,16 +87,17 @@ class Scaffold(FedAvg):
         ), "Only SGD for client optimizer with Scaffold"
 
         super().__init__(
-            training_dataloaders,
-            model,
-            loss,
-            optimizer_class,
-            learning_rate,
-            num_updates,
-            nrounds,
-            log,
-            log_period,
-            bits_counting_function,
+            training_dataloaders=training_dataloaders,
+            model=model,
+            loss=loss,
+            optimizer_class=optimizer_class,
+            learning_rate=learning_rate,
+            num_updates=num_updates,
+            nrounds=nrounds,
+            log=log,
+            log_dir=log_dir,
+            log_period=log_period,
+            bits_counting_function=bits_counting_function,
         )
 
         # initialize the previous state of each client
@@ -116,7 +124,7 @@ class Scaffold(FedAvg):
         ----------
         _model: _Model
             The model on the local device used by the optimization step.
-        dataloader_with_memory : dataloaderwithmemory
+        dataloader_with_memory : DataLoaderWithMemory
             A dataloader that can be called infinitely using its get_samples()
             method.
         correction_state: List

--- a/flamby/strategies/utils.py
+++ b/flamby/strategies/utils.py
@@ -1,5 +1,4 @@
 import copy
-from datetime import datetime
 
 import numpy as np
 import torch
@@ -58,7 +57,15 @@ class _Model:
     """
 
     def __init__(
-        self, model, optimizer_class, lr, loss, client_id=0, log=False, log_period=100
+        self,
+        model,
+        optimizer_class,
+        lr,
+        loss,
+        client_id=0,
+        log=False,
+        log_dir=None,
+        log_period=100,
     ):
         """_summary_
 
@@ -72,9 +79,12 @@ class _Model:
         lr : float
             The learning rate to use with th optimizer class.
         loss : torch.nn.modules.loss._loss
-            an instantiated torch loss.
+            An instantiated torch loss.
         log: bool
             Whether or not to log quantities with tensorboard. Defaults to False.
+        log_dir: str
+            Save directory location. Default is runs/**CURRENT_DATETIME_HOSTNAME**,
+            which changes after each run.
         client_id: int
             The id of the client for logging purposes. Default to 0.
         log_period: int
@@ -87,11 +97,11 @@ class _Model:
         self.model = self.model.to(self._device)
         self.num_batches_seen = 0
         self.log = log
+        self.log_dir = log_dir
         self.log_period = log_period
         self.client_id = client_id
         if self.log:
-            date_now = str(datetime.now())
-            self.writer = SummaryWriter(log_dir=f"./runs/fed_avg-{date_now}")
+            self.writer = SummaryWriter(log_dir=log_dir)
         self.current_epoch = 0
         self.batch_size = None
         self.num_batches_per_epoch = None
@@ -163,7 +173,7 @@ class _Model:
 
         Parameters
         ----------
-        dataloader_with_memory : dataloaderwithmemory
+        dataloader_with_memory : DataLoaderWithMemory
             A dataloader that can be called infinitely using its get_samples()
             method.
         num_updates : int

--- a/tests/strategies/test_cyclic.py
+++ b/tests/strategies/test_cyclic.py
@@ -61,7 +61,7 @@ def test_cyclic(n_clients):
     # tests if fed_avg is not failing on the MNIST dataset
     # with different number of clients
     num_updates = 100
-    nrounds = 50
+    nrounds = 50 * n_clients
     lr = 0.001
     batch_size = 100
 

--- a/tests/strategies/test_fed_avg.py
+++ b/tests/strategies/test_fed_avg.py
@@ -61,7 +61,9 @@ def test_fed_avg(n_clients):
     lr = 0.001
     optimizer_class = torch.optim.Adam
 
-    s = FedAvg(train_dataloader, m, loss, optimizer_class, lr, num_updates, nrounds)
+    s = FedAvg(
+        train_dataloader, m, loss, optimizer_class, lr, num_updates, nrounds, log=True
+    )
     m = s.run()
 
     res = evaluate_model_on_tests(m[0], [test_dataloader], accuracy)

--- a/tests/strategies/test_fed_prox.py
+++ b/tests/strategies/test_fed_prox.py
@@ -69,7 +69,17 @@ def test_fed_prox_integration(n_clients):
     mu = 0.1
     optimizer_class = torch.optim.Adam
 
-    s = FedProx(train_dataloader, m, loss, optimizer_class, lr, num_updates, nrounds, mu)
+    s = FedProx(
+        train_dataloader,
+        m,
+        loss,
+        optimizer_class,
+        lr,
+        num_updates,
+        nrounds,
+        mu,
+        log=True,
+    )
     m = s.run()
 
     def accuracy(y_true, y_pred):

--- a/tests/strategies/test_scaffold.py
+++ b/tests/strategies/test_scaffold.py
@@ -69,7 +69,9 @@ def test_scaffold_integration(n_clients):
     lr = 0.1
     optimizer_class = torch.optim.SGD
 
-    s = Scaffold(train_dataloader, m, loss, optimizer_class, lr, num_updates, nrounds)
+    s = Scaffold(
+        train_dataloader, m, loss, optimizer_class, lr, num_updates, nrounds, log=True
+    )
     m = s.run()
 
     def accuracy(y_true, y_pred):


### PR DESCRIPTION
The purpose of this PR is to fix #77.  This PR mainly adds default `log_dir` to all strategies. The default `log_dir` name follows the template `{SRATEGY}_{DATE}`. It was tested on cyclic, fedavg, and fedprox. 