### PR TITLE
Typo in path to doc in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ make html
 ```
 This will generate html pages in the folder _builds/html that can be accessed in your browser:
 ```bash
-open _builds/html/index.html
+open _build/html/index.html
 ```
 ## Contributing
 


### PR DESCRIPTION
In README.md, the path to the doc once built contained a typo