### PR TITLE
fix: openslide install in correct env

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,43 @@
+import sys
+from subprocess import call, check_call
+
 from setuptools import find_packages, setup
+from setuptools.command.develop import develop
+from setuptools.command.egg_info import egg_info
+from setuptools.command.install import install
+
+# Histolab has a dependency that requires options
+histolab_dep_commands = [
+    sys.executable,  # the python interpreter (needed to install in the right pipenv)
+    "-m",
+    "pip",
+    "install",
+    "large-image-source-openslide",
+    "--find-links",
+    "https://girder.github.io/large_image_wheels",
+]
+
+
+class CustomInstallCommand(install):
+    def run(self):
+        install.run(self)
+        command = call(histolab_dep_commands)
+        assert command == 0
+
+
+class CustomDevelopCommand(develop):
+    def run(self):
+        develop.run(self)
+        command = call(histolab_dep_commands)
+        assert command == 0
+
+
+class CustomEggInfoCommand(egg_info):
+    def run(self):
+        egg_info.run(self)
+        command = check_call(histolab_dep_commands)
+        assert command == 0
+
 
 # datasets has a dependency that requires options
 camelyon16 = [
@@ -85,4 +124,9 @@ setup(
     author_email="unknown",
     packages=find_packages(),
     include_package_data=True,
+    cmdclass={
+        "install": CustomInstallCommand,
+        "develop": CustomDevelopCommand,
+        "egg_info": CustomEggInfoCommand,
+    },
 )


### PR DESCRIPTION
With the current setup the `large-image-source-openslide` is installed in the base environment instead of the flamby one.

It is probably coming from setuptools additional calls.
If the current PR is not a satisfactory fix we can dive deeper into how to update cmdclass call so it uses the correct environment.

This PR makes the `large-image-source-openslide` to be installed within flamby environment.
Downsides of this solution:
- it installs it for all the dataset-installation while it could do so only for cam16 (which will be the case when using cmdclass anyway)
- if the user chooses to use `pip` directly instead of `make` they will need to install it manually in addition