### PR TITLE
FIX random number generator

### DIFF
--- a/flamby/datasets/split_utils.py
+++ b/flamby/datasets/split_utils.py
@@ -81,8 +81,11 @@ def split_indices_dirichlet(
     orig_centers_indices = np.unique(original_table["train"][0])
     num_orig_centers = orig_centers_indices.size
 
+    # Generate random numbers with seed
+    rng = np.random.default_rng(seed)
+
     # Draw the attribution params for each dataset
-    proba_new_centers = np.random.dirichlet(
+    proba_new_centers = rng.dirichlet(
         dirichlet_param * np.ones(num_target_centers), size=(num_orig_centers)
     )
     # Check that the expected number of samples per dataset is large enough


### PR DESCRIPTION
This PR fixes the usage of the seed for the split with Dirichlet allocation: the seed passed was not used