### PR TITLE
Fixing _num_batches_per_epoch calculation

### DIFF
--- a/flamby/strategies/utils.py
+++ b/flamby/strategies/utils.py
@@ -193,7 +193,7 @@ class _Model:
                 # edge cases with drop_last=False
                 _batch_size = X.shape[0]
                 _num_batches_per_epoch = (_size // _batch_size) + int(
-                    (_size % _batch_size) == 0
+                    (_size % _batch_size) != 0
                 )
             # Compute prediction and loss
             _pred = self.model(X)
@@ -259,7 +259,7 @@ class _Model:
                 # edge cases with drop_last=False
                 _batch_size = X.shape[0]
                 _num_batches_per_epoch = (_size // _batch_size) + int(
-                    (_size % _batch_size) == 0
+                    (_size % _batch_size) != 0
                 )
             # Compute prediction and loss
             _pred = self.model(X)
@@ -331,7 +331,7 @@ class _Model:
                 # edge cases with drop_last=False
                 _batch_size = X.shape[0]
                 _num_batches_per_epoch = (_size // _batch_size) + int(
-                    (_size % _batch_size) == 0
+                    (_size % _batch_size) != 0
                 )
             # We will implement correction by modifying loss as
             # corrected_loss = loss - correction @ model_params.

--- a/integration/FedML/flamby-integration-into-fedml.md
+++ b/integration/FedML/flamby-integration-into-fedml.md
@@ -1,4 +1,4 @@
-# Using FLamby with Fed-BioMed
+# Using FLamby with FedML
 
 This document highlights how to interface FLamby with [FedML](https://github.com/FedML-AI/FedML).
 


### PR DESCRIPTION
E.g. dataset of size 10, batch_size 2 would have a _num_batches_per_epoch equal to 6 with `+ int((_size % _batch_size) == 0)`