### PR TITLE
Fix MANIFEST.in syntax

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-recursive-include flamby/*.csv
+recursive-include flamby/ *.csv

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-recursive-include flamby/ *.csv
+recursive-include flamby *.csv


### PR DESCRIPTION
Hi, 
I am a colleague of @AyedSamy from INRIA, France. 

I noticed that your `MANIFEST.in` was being ignored (i.e. I could not find .csv files after pip install), and I believe it may be due to a non-compliance with the [syntax](https://packaging.python.org/en/latest/guides/using-manifest-in/) of `recursive-include`. 

I hope this helps, thanks for the great work of this community!