### PR TITLE
ENH: simplify conditional action for documentation

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,7 +1,12 @@
 name: Docs
-env: 
+env:
   SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL: True
-on: [push, pull_request, workflow_dispatch]
+# Only run when pushing to main from a pull request
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 jobs:
   docs:
     runs-on: ubuntu-latest
@@ -9,11 +14,11 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.10' 
+          python-version: '3.10'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ."[all_extra]"  
+          pip install -e ."[all_extra]"
       - name: Sphinx build
         run: |
           sphinx-build docs _build


### PR DESCRIPTION
The previous documentation.yml file makes the same job run twice, one for the `push` action and the other for the `pull_request` action. This PR corrects it so that only 1 job is run, which saves some energy and money.