### PR TITLE
ENH Add weekly CI

### DIFF
--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - main
   pull_request:
+  schedule:
+    # Every monday at 3h30 UTC
+    - cron: '30 3 * * 1'
 
 env:
   SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL: True


### PR DESCRIPTION
This PR adds a weekly CI run, to ensure that there is no issue due to version bumps in python dependencies.