### PR TITLE
feat: Improve histolab tiling

### DIFF
--- a/flamby/datasets/fed_camelyon16/dataset_creation_scripts/tiling_slides.py
+++ b/flamby/datasets/fed_camelyon16/dataset_creation_scripts/tiling_slides.py
@@ -51,7 +51,7 @@ class SlideDataset(IterableDataset):
         # add uniform color borders to the slide to prevent artifact detection
         add_borders(slide)
         # tissue mask is needed to segment all regions
-        # some slides need a refined version of the tissue mask
+        # This custom tissue mask has proved to be much more robust on this dataset
         self.it = grid_tiles_extractor._tiles_generator(
             slide,
             extraction_mask=TissueMask(

--- a/flamby/datasets/fed_camelyon16/dataset_creation_scripts/tiling_slides.py
+++ b/flamby/datasets/fed_camelyon16/dataset_creation_scripts/tiling_slides.py
@@ -25,20 +25,17 @@ from flamby.utils import read_config, write_value_in_config
 def add_borders(slide: Slide, width: int = 10):
     """Add borders to a slide thumbnail of the mean slide color.
 
-    This helps removing artefacts on the borders and prevents histolab TissuMask to
+    This helps removing artifacts on the borders and prevents histolab TissuMask to
     make incorrect detections.
     """
     pixels = slide.thumbnail.load()
-    pixel_values = np.zeros((slide.thumbnail.size[0], slide.thumbnail.size[1], 3))
-    for i in range(slide.thumbnail.size[0]):
-        for j in range(slide.thumbnail.size[1]):
-            pixel_values[i, j, :] = list(pixels[i, j])
-    mean_value = tuple(int(np.mean(pixel_values[:, :, i])) for i in range(3))
+    pixel_values = np.array(slide.thumbnail)
+    mean_value = tuple(map(int, np.mean(pixel_values, axis=(0, 1))))
+    # in place modification of slide.thumbnail object
     for i in range(width):
         for j in range(slide.thumbnail.size[1]):
             pixels[i, j] = mean_value
             pixels[-i, j] = mean_value
-
     for j in range(width):
         for i in range(slide.thumbnail.size[0]):
             pixels[i, j] = mean_value

--- a/flamby/datasets/fed_camelyon16/dataset_creation_scripts/tiling_slides.py
+++ b/flamby/datasets/fed_camelyon16/dataset_creation_scripts/tiling_slides.py
@@ -48,7 +48,7 @@ def add_borders(slide: Slide, width: int = 10):
 class SlideDataset(IterableDataset):
     def __init__(self, grid_tiles_extractor, slide, transform=None):
         self.transform = transform
-        # add uniform color borders to the slide to prevent artifact detection
+        # add uniform color borders to the slide to prevent artifact detection on the borders
         add_borders(slide)
         # tissue mask is needed to segment all regions
         # This custom tissue mask has proved to be much more robust on this dataset


### PR DESCRIPTION
Using custom histolab filters and adding a uniform color border to the slide improves histolab tissue detection and hence leads to a better tiling, getting
![tumor_083_fixed_mask_with_borders_histolab](https://github.com/owkin/FLamby/assets/153643450/5c17210f-a606-4826-bb06-7709eb2bf940)
instead of
![tumor_083_default_mask_without_borders_histolab](https://github.com/owkin/FLamby/assets/153643450/8243c440-2175-4325-bf6a-53088a1264a2)
