### PR TITLE
chore: Remove python 3.7 support

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -15,11 +15,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     matrix:
       os: [ubuntu-latest]
-      python: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+      python: ["3.8", "3.9", "3.10", "3.11"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
           python-version: ${{ matrix.python }}

--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -21,9 +21,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python: ["3.8", "3.9", "3.10", "3.11"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ please open a github issue on this repository.
 
 ## Installation
 
-We recommend using anaconda and pip. You can install anaconda by downloading and executing appropriate installers from the [Anaconda website](https://www.anaconda.com/products/distribution), pip often comes included with python otherwise check [the following instructions](https://pip.pypa.io/en/stable/installation/). We support all Python version starting from **3.7**.
+We recommend using anaconda and pip. You can install anaconda by downloading and executing appropriate installers from the [Anaconda website](https://www.anaconda.com/products/distribution), pip often comes included with python otherwise check [the following instructions](https://pip.pypa.io/en/stable/installation/). We support all Python version starting from **3.8**.
 
 You may need `make` for simplification. The following command will install all packages used by all datasets within FLamby. If you already know you will only need a fraction of the datasets inside the suite you can do a partial installation and update it along the way using the options described below.
 Create and launch the environment using:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,7 +1,7 @@
 Installation
 ------------
 
-We recommend using anaconda and pip. You can install anaconda by downloading and executing appropriate installers from the `Anaconda website <https://www.anaconda.com/products/distribution>`_\ , pip often comes included with python otherwise check `the following instructions <https://pip.pypa.io/en/stable/installation/>`_. We support all Python version starting from **3.7**.
+We recommend using anaconda and pip. You can install anaconda by downloading and executing appropriate installers from the `Anaconda website <https://www.anaconda.com/products/distribution>`_\ , pip often comes included with python otherwise check `the following instructions <https://pip.pypa.io/en/stable/installation/>`_. We support all Python version starting from **3.8**.
 
 You may need ``make`` for simplification. The following command will install all packages used by all datasets within FLamby. If you already know you will only need a fraction of the datasets inside the suite you can do a partial installation and update it along the way using the options described below.
 Create and launch the environment using:

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 setup(
     name="flamby",
     version="0.0.1",
-    python_requires=">=3.7.0",
+    python_requires=">=3.8.0",
     license="MIT",
     classifiers=[
         "Topic :: Scientific/Engineering :: Artificial Intelligence",


### PR DESCRIPTION
python 3.7 is not supported any more since 2023-06-27, consequently FLamby will not support it either